### PR TITLE
Fix LT issue.

### DIFF
--- a/Assets/Scripts/TreeController.cs
+++ b/Assets/Scripts/TreeController.cs
@@ -227,7 +227,7 @@ public class TreeController : MonoBehaviour {
 
 			}
 			// Handle Break
-			else if (Input.GetButtonDown(GameModel.BREAK)) {
+			else if (CheckEpsilon(Input.GetAxis(GameModel.BREAK)) || (Input.GetButtonDown(GameModel.BREAK))) {
 				float distance = float.MaxValue;
 				GameObject closestBranch = null;
 				Collider[] colliders = Physics.OverlapSphere(_reticle.transform.position, minDistance);

--- a/Assets/Scripts/TreeController.cs
+++ b/Assets/Scripts/TreeController.cs
@@ -227,7 +227,7 @@ public class TreeController : MonoBehaviour {
 
 			}
 			// Handle Break
-			else if (CheckEpsilon(Input.GetAxis(GameModel.BREAK)) || (Input.GetButtonDown(GameModel.BREAK))) {
+			if (CheckEpsilon(Input.GetAxis(GameModel.BREAK)) || (Input.GetButtonDown(GameModel.BREAK))) {
 				float distance = float.MaxValue;
 				GameObject closestBranch = null;
 				Collider[] colliders = Physics.OverlapSphere(_reticle.transform.position, minDistance);


### PR DESCRIPTION
Another small one. 

Stopgap measure to fix broken `LT` input on controller. One line fix.
- Checks epsilon of `Input.GetAxis` or `Input.GetButtonDown`, if either are true, does the delete.
- This does mean that it's easy to accidentally delete multiple close branches on an Xbox controller, but at least the binding works.