### PR TITLE
Implement .gitconfig to use Unity merge tool

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,6 @@
+[merge]
+tool = unityyamlmerge
+
+[mergetool "unityyamlmerge"]
+trustExitCode = false
+cmd = '<path to UnityYAMLMerge>' merge -p "$BASE" "$REMOTE" "$LOCAL" "$MERGED"


### PR DESCRIPTION
This will add the UnityYAMLMerge tool to git's repository configuration for use with `git mergetool`.

This will help with resolving merge conflicts. When merging from another branch, do `git fetch`, then `git mergetool`. Optionally you may provide a file path specification to run the tool on specific files.

**Important Note:**
Each user will need to execute the following command exactly once: `git config --local include.path ../.gitconfig`

This is because for security reasons, git does not automatically enable repository configuration that wasn't generated locally.